### PR TITLE
Add Logging and Trigger on latest Tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddeb19ee86cb16ecfc871e5b0660aff6285760957aaedda6284cf0e790d3769"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen",
  "cc",
@@ -851,12 +851,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1231,7 +1231,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1439,9 +1439,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ async fn handle_webhook(
         println!("[{:?}] Sending Discord notification...", SystemTime::now());
         match Client::new()
             .post(&webhook_url)
-            .json(&json!({"content": "🚀 Haibi-chan deployed the **latest** version of PeraPera Quest!"}))
+            .json(&json!({"content": "Haibi-chan has deployed a new version of PeraPera Quest!"}))
             .send()
             .await
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,8 +201,16 @@ async fn handle_webhook(
             .send()
             .await
         {
-            Ok(resp) => println!("[{:?}] Discord notification sent with status: {}", SystemTime::now(), resp.status()),
-            Err(err) => eprintln!("[{:?}] Failed to send Discord notification: {:?}", SystemTime::now(), err),
+            Ok(resp) => println!(
+                "[{:?}] Discord notification sent with status: {}",
+                SystemTime::now(),
+                resp.status()
+            ),
+            Err(err) => eprintln!(
+                "[{:?}] Failed to send Discord notification: {:?}",
+                SystemTime::now(),
+                err
+            ),
         }
     });
 


### PR DESCRIPTION
When GitHub publishes the `package` webhook, it does so for every tag.
So recently, when I published `0.0.4`, it sent four webhook requests to haibi-chan.
- `0`
- `0.0`
- `0.0.4`
- `latest`

This is expected behavior; `0.0.4` was published, and the tags `0`, `0.0`, and `latest` all moved to point to this new version instead of `0.0.3`.
However, haibi-chan tried to publish each one individually, and that's not what we want.
We're not really concerned about the version shuffle, but we do want to respond to the `latest` tag.
If that one gets updated, we'd like haibi-chan to deploy that version to the server.
So the code is modified to only act on the `latest` tag.

Next, we add some logging.
Normally we'd probably use `tracing` and some other crates to create a proper logging solution; logfiles, rotation, etc.
But here we're just printing things to `stdout` and `stderr`.

I could try to take the high road and say we're following the [12 Factor App rule for logging](https://12factor.net/logs):

>A twelve-factor app never concerns itself with routing or storage of its output stream. It should not attempt to write to or manage logfiles. Instead, each running process writes its event stream, unbuffered, to stdout.

But the truth is this logging is good enough, and there are more valuable features to develop than gold plating the logging of a utility microservice.
